### PR TITLE
Use java.net.preferIPv4Stack=true in WF env settings

### DIFF
--- a/drools-wb/base/Dockerfile
+++ b/drools-wb/base/Dockerfile
@@ -17,7 +17,7 @@ ENV KIE_CONTEXT_PATH drools-wb
 ENV KIE_SERVER_PROFILE standalone-full
 # Do NOT use demo neither examples by default in this image (no internet connection required).
 ENV KIE_DEMO false
-ENV JAVA_OPTS -Xms256m -Xmx512m
+ENV JAVA_OPTS -Xms256m -Xmx512m -Djava.net.preferIPv4Stack=true
 
 ####### DROOLS-WB ############
 RUN curl -o $HOME/$KIE_CONTEXT_PATH.war $KIE_REPOSITORY/org/kie/kie-drools-wb-distribution-wars/$KIE_VERSION/kie-drools-wb-distribution-wars-$KIE_VERSION-$KIE_CLASSIFIER.war && \

--- a/drools-wb/showcase/Dockerfile
+++ b/drools-wb/showcase/Dockerfile
@@ -12,6 +12,7 @@ MAINTAINER "Michael Biarnes Kiefer" "mbiarnes@redhat.com"
 # Use demo and examples by default in this showcase image (internet connection required).
 ENV KIE_DEMO true
 ENV KIE_SERVER_PROFILE standalone-full-drools
+ENV JAVA_OPTS -Xms256m -Xmx512m -Djava.net.preferIPv4Stack=true
 
 ####### Drools Workbench CUSTOM CONFIGURATION ############
 ADD etc/standalone-full-drools.xml $JBOSS_HOME/standalone/configuration/standalone-full-drools.xml

--- a/kie-server/base/Dockerfile
+++ b/kie-server/base/Dockerfile
@@ -14,7 +14,7 @@ ENV KIE_REPOSITORY https://repository.jboss.org/nexus/content/groups/public-jbos
 ENV KIE_VERSION 6.5.0.Final
 ENV KIE_CLASSIFIER ee7
 ENV KIE_CONTEXT_PATH kie-server
-ENV JAVA_OPTS -Xms256m -Xmx512m
+ENV JAVA_OPTS -Xms256m -Xmx512m -Djava.net.preferIPv4Stack=true
 
 ###### SWITCH USER root ######
 USER root

--- a/kie-server/showcase/Dockerfile
+++ b/kie-server/showcase/Dockerfile
@@ -19,6 +19,7 @@ ENV KIE_SERVER_CONTROLLER_PWD admin
 ENV KIE_MAVEN_REPO http://localhost:8080/kie-wb/maven2
 ENV KIE_MAVEN_REPO_USER admin
 ENV KIE_MAVEN_REPO_PASSWORD admin
+ENV JAVA_OPTS -Xms256m -Xmx512m -Djava.net.preferIPv4Stack=true
 
 ####### Drools KIE Server CUSTOM CONFIGURATION ############
 RUN mkdir -p $HOME/.m2


### PR DESCRIPTION
@mbiarnes Can you please take a look? This solves WF startup issues described in https://hub.docker.com/r/jboss/jbpm-workbench-showcase/. I think we should gear towards settings that work for most of the users out of the box.

`15:43:12,773 ERROR [org.jboss.msc.service.fail] (MSC service thread 1-4) MSC000001: Failed to start service jboss.undertow.listener.default: org.jboss.msc.service.StartException in service jboss.undertow.listener.default: Could not start http listener
    at org.wildfly.extension.undertow.ListenerService.start(ListenerService.java:142)
    at org.jboss.msc.service.ServiceControllerImpl$StartTask.startService(ServiceControllerImpl.java:1948)
    at org.jboss.msc.service.ServiceControllerImpl$StartTask.run(ServiceControllerImpl.java:1881)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
    at java.lang.Thread.run(Thread.java:745)
Caused by: java.net.SocketException: Protocol family unavailable
    at sun.nio.ch.Net.bind0(Native Method)
    at sun.nio.ch.Net.bind(Net.java:433)
    at sun.nio.ch.Net.bind(Net.java:425)
    at sun.nio.ch.ServerSocketChannelImpl.bind(ServerSocketChannelImpl.java:223)
    at sun.nio.ch.ServerSocketAdaptor.bind(ServerSocketAdaptor.java:74)
    at org.xnio.nio.NioXnioWorker.createTcpConnectionServer(NioXnioWorker.java:190)
    at org.xnio.XnioWorker.createStreamConnectionServer(XnioWorker.java:243)
    at org.wildfly.extension.undertow.HttpListenerService.startListening(HttpListenerService.java:126)
    at org.wildfly.extension.undertow.ListenerService.start(ListenerService.java:138)
    ... 5 more`