### PR TITLE
Make auth compatibile with jbpm-workbench-showcase

### DIFF
--- a/kie-server/showcase/etc/kie-server-roles.properties
+++ b/kie-server/showcase/etc/kie-server-roles.properties
@@ -1,1 +1,7 @@
 kieserver=kie-server
+admin=kie-server
+krisv=kie-server
+john=kie-server
+sales-rep=kie-server
+katy=kie-server
+jack=kie-server

--- a/kie-server/showcase/etc/kie-server-users.properties
+++ b/kie-server/showcase/etc/kie-server-users.properties
@@ -1,1 +1,7 @@
 kieserver=kieserver1!
+admin=admin
+krisv=krisv
+john=john
+sales-rep=sales-rep
+katy=katy
+jack=jack

--- a/kie-server/showcase/etc/standalone-full-kie-server.xml
+++ b/kie-server/showcase/etc/standalone-full-kie-server.xml
@@ -355,8 +355,8 @@
                     <authentication>
                         <!-- Drools KIE Server - CUSTOM LOGIN MODULE -->
                         <login-module code="UsersRoles" flag="required">
-                            <module-option name="usersProperties" value="${jboss.server.config.dir}/kie-server-users.properties"/>
-                            <module-option name="rolesProperties" value="${jboss.server.config.dir}/kie-server-roles.properties"/>
+                            <module-option name="usersProperties" value="file:///${jboss.server.config.dir}/kie-server-users.properties"/>
+                            <module-option name="rolesProperties" value="file:///${jboss.server.config.dir}/kie-server-roles.properties"/>
                         </login-module>
                     </authentication>
                 </security-domain>


### PR DESCRIPTION
The goal of this changes is to make kie-server-showcase ready to be used by jbpm-workbench-showcase.

As jbpm-console uses it's users to authenticate against kie-server when getting process definitions and list I synchronized the list of users with jbpm-workbench-showcase.

This also fixes missing protocol in users & roles specification.