### PR TITLE
Fix wrong version 7.6.0 to 7.7.0

### DIFF
--- a/kie-server/base/Dockerfile
+++ b/kie-server/base/Dockerfile
@@ -11,7 +11,7 @@ MAINTAINER "Michael Biarnes Kiefer" "mbiarnes@redhat.com"
 ####### ENVIRONMENT ############
 ENV JBOSS_BIND_ADDRESS 0.0.0.0
 ENV KIE_REPOSITORY https://repository.jboss.org/nexus/content/groups/public-jboss
-ENV KIE_VERSION 7.6.0.Final
+ENV KIE_VERSION 7.7.0.Final
 ENV KIE_CLASSIFIER ee7
 ENV KIE_CONTEXT_PATH kie-server
 ENV JAVA_OPTS -Xms256m -Xmx1024m -Djava.net.preferIPv4Stack=true


### PR DESCRIPTION
Wrong version in Dockerfile. Use old version 7.6.0, but need 7.7.0. Fixed